### PR TITLE
Migrar artículos de revista

### DIFF
--- a/content/articles/2014-05-17-Sobre-Bytes-Libres.md
+++ b/content/articles/2014-05-17-Sobre-Bytes-Libres.md
@@ -1,0 +1,40 @@
+Title: Sobre la sección Bytes Libres
+Date: 2014-05-17
+Author:  Chico
+Category: Revista
+Tags: Bytes Libres
+
+Desde éste año, 2014, los miembros del GULAG han empezado a escribir en la sección Bytes Libres en el periódico El Siglo de Torreón.
+
+La sección Bytes Libres es diferente a las demás, no por que se habla en ella sobre temas relacionados con el software libre, con GNU/Linux o con temas relacionados. No, es diferente por una cosa: sus autores.
+
+<!-- break -->
+
+En la sección escriben miembros en activo del GULAG, pero no solo uno sino todos aquellos que deseen participar y sean miembros activos del GULAG. Todos los que buscamos de una o de otra forma promover el Software Libre y GNU/Linux. El nombre de la sección fue propuesto, votado y aceptado por los muchachos del GULAG.
+
+Éste proyecto no seria posible sin la gestión de Gabriel Peña con el personal correspondiente del Siglo de Torreón, y por la colaboración de los integrantes del GULAG con distintos artículos, mismos que se pueden ver al final de la presente nota.
+
+A todos los que colaboramos de una u otra forma con éste proyecto, difundir el Software Libre escribiendo en éste espacio, les agradezco e invito a que sigan participando con los ánimos que los caracterizan.
+
+### Artículos publicados
+
+**17 de julio 2014** [Seguridad con Software Libre](http://www.elsiglodetorreon.com.mx/noticia/1017146.bytes-libres-seguridad-con-software-libre.html) _Por Chico_
+
+**20 de junio 2014** [Revoluciónate a ti mismo, sé un programador](http://www.elsiglodetorreon.com.mx/noticia/1007916.bytes-libres.html) _Por Guivaloz_
+
+**5 de junio 2014** [Software Libre y transparencia](http://www.elsiglodetorreon.com.mx/noticia/1002479.bytes-libres.html) _Por Chico_
+
+**22 de mayo 2014** [Usando Chromecast](http://www.elsiglodetorreon.com.mx/noticia/997022.bytes-libres.html) _Por Rive_
+
+**8 de mayo 2014** [Una distribución educativa](http://www.elsiglodetorreon.com.mx/noticia/991260.bytes-libres.html) _Por Guabyboy_
+
+**24 de abril 2014** [El software libre como herramienta para la educación](http://www.elsiglodetorreon.com.mx/noticia/985920.el-software-libre-como-herramienta-para-la-educacion.html) _Por Linuxman_
+
+**27 de marzo 2014** [Las libertades del Software Libre](http://www.elsiglodetorreon.com.mx/noticia/976561.bytes-libres.html) _Por Chico_
+
+**13 de marzo 2014** [Adiós Wordpress, 2014 será el año de los CMS de archivos planos](http://www.elsiglodetorreon.com.mx/noticia/971928.bits-libres.html) _Por Guivaloz_
+
+**21 de febrero 2014** [OpenStreetMap](http://www.elsiglodetorreon.com.mx/noticia/965041.bytes-libres.html) _Por Guivaloz_
+
+**14 de febrero 2014** [Conociendo el GULAG](http://www.elsiglodetorreon.com.mx/noticia/962699.bytes-libres.html) _Por Chico_
+

--- a/content/articles/2014-05-17-opensuse-life-linux-for-education.md
+++ b/content/articles/2014-05-17-opensuse-life-linux-for-education.md
@@ -1,0 +1,32 @@
+Title: OpenSUSE Li-F-E Linux For Education Distribución Educativa
+Date: 2014-05-17
+Author: guabyboy
+Category: Revista
+Tags: OpenSUSE Educativo
+
+La utilización de GNU/Linux es muy noble en ambientes educativos, no por la gratuidad del software, sino por la variedad de aplicaciones con que cuentan las distribuciones educativas de GNU/Linux,  por eso, en esta ocasión,  les hablaré de OpenSUSE  para la educación.
+
+Normalmente, a los usuarios  de cualquier sistema, al aprender autilizarlo, no les interesa cambiar o experimentar, esto es muy normal, el miedo al cambio o salir de su zona de confort. Por eso la gran fortaleza del sistema operativo GNU/Linux en muchas de sus distribuciones, es la capacidad de poderse probar  en su totalidad en vivo, es decir, sin necesidad de instalarse .
+
+Para probar OpenSUSE Li-F-E (Linux For Education), solo es necesario tener el disco grabado y arrancar nuestra computadora desde el lector de  DVD. La imagen completa del dvd se puede descargar de http://sourceforge.net/projects/opensuse-edu/files/download/ISOs/openSUSE-Edu-li-f-e.x86_64-13.1.1.iso/download, solo hay que quemar el dvd y listo; es una versión en vivo para probarla, disfrutarla e instalarla se se desea, pero si no se cuenta con unidad lectora de disco, también se puede acceder desde una memoria USB de al menos 4Gb.
+
+<!-- break -->
+
+Para los usuarios de MS-Windows, que deseen crear un USB para poder arrancar desde esta memoria, tienen que generar la USB utilizando ImageWriter y no otro (lo podemos descargar  desde https://github.com/downloads/openSUSE/kiwi/ImageWriter.exe) y tener previamente instalados en la computadora el WindowsInstaller-KB893803-v2-x86 (descargable desde la página oficial de Microsoft) y el NetFx20SP1_x86 (http://download.microsoft.com/download/0/8/c/08c19fa4-4c4f-4ffb-9d6c-150906578c9e/NetFx20SP1_x86.exe).
+
+Solo que la versión de ImageWriter para windows solo acepta imágenes de disco en formato raw y no en iso. La solución es muy sencilla, al momento de descargar y guardar la imagen, la guardamos con el_nombre_que_deseamos.raw, al tenerla en nuestro  disco duro,  doble click sobre ImageWriter.exe y  generamos la USB. Si se nos olvido cambiarle el nombre o no pudimos, la opción que nos da Windows es renombrar el archivo openSUSE-Edu-li-f-e.x86_64-13.1.1.iso por el_nombre_que_deseamos.raw.
+¿Y como hacemos eso? bien, primero ubicamos,con el navegador  de archivos, la carpeta donde esta la imagen ISO (vamos a suponer que se encuentra en la carpeta de Descargas dentro de Mis documentos), luego buscamos en el menú de Inicio, Accesorios, Símbolo de sistema (click o entrar) y entramos a una pantalla en modo texto, normalmente nos ubica en
+
+- c:\Documents and Settings\usuario>   en esa pantalla negra tecleamos:
+
+- cd mis documentos      (entrar)
+
+- cd descargas           (entrar)
+
+- rename openSUSE-Edu-li-f-e.x86_64-13.1.1.iso el_nombre_que_deseamos.raw
+
+Toda la línea anterior al mismo  tiempo, aunque pase de renglón, antes de entrar, verificamos en el navegador de archivos, doble click sobre ImageWriter.exe y buscamos la imagen .raw y generamos nuestro USB.
+
+Ahora si hablaré de openSUSE-Edu-li-f-e, tiene una gran varidad de aplicaciones ya configuradas, que comprende desde  aplicaciones para peques de prescolar hasta universitarios (podemos leer un poco en http://en.opensuse.org/openSUSE:Education-Li-f-e#Educational) sin dejar de lado al usuario común que require de una ofimática (Libre Office), navegación en internet, reproducción de música y video, edición y  retoque fotográfico, hasta funciones mas complejas como diseño con un sistema CAD (QCad) o software para modelado y animación 3D (Blender), sin pasar por alto los juegos educativos como TuxMath o pasatiempos científicos con un observatorio virtual en tiempo real con Stellarium.
+
+Imposible hablar de todas las opciones disponibles en esta distribucion GNU/Linux educativa, por lo que los invito a descargarla y probarla.

--- a/content/articles/2014-05-19-revolucionate-a-ti-mismo-se-un-programador copy.md
+++ b/content/articles/2014-05-19-revolucionate-a-ti-mismo-se-un-programador copy.md
@@ -1,0 +1,33 @@
+Title: Revoluciónate a tí mismo, sé un programador
+Date: 2014-05-19
+Author: guivaloz
+Category: Revista
+Tags: Programar, Sé un programador
+
+_Saber programar es conocer diferencia entre ver un reloj desde afuera y saber cómo funciona en su interior._
+
+En este tiempo, la edad dorada de la informática, vemos que ya es un hecho que _casi_ todos disponemos de dispositivos digitales complejos; háblese de computadoras, _laptops_, _tablets_ o celulares _inteligentes_. Como es natural, de todas estas personas, la mayoría son usuarios y la minoría son _creadores_, es decir, quienes hacen programas para que los usen. Lamentablemente esta situación es igual en personas que ejercen las diferentes ramas de la informática; **en la mayoría de nosotros hay muy pocos con entusiasmo para programar**, se prefieren las labores de venta, instalación, comunicaciones, etc.
+
+¿Qué sería de nuestra ciudad/estado/país/mundo si todo profesionista dedicara algo de su labor a la programación?. Y en general, para el nivel escolar, **si no sólo hubiera las típicas clases de computación, sino también talleres de programación**, ¿sería esto una gran herramienta para su futuro?. Seguramente que sí.
+
+<!-- break -->
+
+### La zanahoria para que camine el burro
+
+Así que, en mi ámbito familiar, motivé a mi hija a que tomara un [curso en línea de programación en Ruby](http://www.codecademy.com/). Ocurre que como todo adolescente, inmerso en la modernidad celular/tablet/internet ella tiene grandes habilidades para manejar estos dispositivos y el internet. Pero es escaso su interés en la programación, aunado a ello, **en su escuela secundaria es un tema que no se ve o se toca muy superficialmente**.
+
+Así que, para que _camine el burro_ se tiene que poner _una zanahoria por delate_. Un estímulo económico por completar el curso en [Codecademy](http://www.codecademy.com/).
+
+Cuando yo tenía su edad fue cuando empecé a programar BASIC en una [Timex Sinclair 1000](https://en.wikipedia.org/wiki/Timex_Sinclair_1000) y vaya que lo disfruté. **Lo que en aquel entonces fue mi pasatiempo ahora es mi profesión.**
+
+### El gran descubrimiento
+
+Todo esto culmina cuando en un punto intermedio del curso, ella se da cuenta de lo que está aprendiendo. Esto la lleva a formular una simple pregunta: **¿porqué no nos enseñan a programar en la escuela?**. Claro que al escuchar ésto hace _temblar_ mi confianza en el de por sí mal prestigiado sistema educativo mexicano.
+
+### Deberíamos enseñar a programar en las escuelas
+
+No mal interpreten esto último pensando en que los alumnos tengan que hacer complejos sistemas. Me apoyo en el ideal de que **el aula debe tratar cubrir todos los temas y buscar el desarrollo de habilidades**; haciendo énfasis en las ciencias: matemáticas, física, química, etc. **El aprender a programar nos ayuda a crear en nuestros cerebros la capacidad de solucionar problemas abstractos.** Además, **un taller de cómputo estimula el trabajo en equipo** y quita el estigma de _nerd_ de los apasionados a las computadoras.
+
+Por último, les invito a ver [El trabajo del futuro: programar](https://www.youtube.com/watch?v=g4lHljws4c8)...
+
+<iframe width="560" height="315" src="//www.youtube.com/embed/g4lHljws4c8" frameborder="0" allowfullscreen></iframe>

--- a/content/articles/2016-05-10-Bits-Libres.md
+++ b/content/articles/2016-05-10-Bits-Libres.md
@@ -1,0 +1,81 @@
+Title: Sobre la sección Bits Libres
+Date: 2016-05-10
+Author:  Chico
+Category: Revista
+Tags: Bits Libres
+
+Inicia el mes de mayo del 2016 y artículos de la GULAG aparecen de nuevo en un medio impreso, en el periódico [Entretodos](http://periodicoentretodos.com/) con la sección Bits Libres.
+
+<!-- break -->
+
+### Artículos publicados
+
+**Mayo 2019** [Cámara de eco](http://www.gulag.org.mx/entradas/2019-05-01-Bits-Libres-Camara-de-eco.html) _Por Chico_
+
+**Enero 2019** [Trabajemos con transparencia](http://www.gulag.org.mx/entradas/2019-01-01-Bits-Libres-Trabajemos-con-transparencia.html) _Por Chico_
+
+**Diciembre 2018** [Compartiendo lo mejor de nosotros](http://www.gulag.org.mx/entradas/2018-12-01-Bits-Libres-Compartiendo-lo-mejor-de-nosotros.html) _Por Chico_
+
+**Noviembre 2018** [Resistencia al cambio](http://www.salazarysanchez.com/entradas/2018-11-01-Bits-Libres-Resistencia-al-cambio.html) _Por Chico_
+
+**Octubre 2018** [Más mujeres en TICs](http://www.salazarysanchez.com/entradas/2018-10-01-Bits-Libres-Mas-Mujeres-en-TICs.html) _Por Chico_
+
+**Septiembre 2018** [Feliz cumpleaños](http://www.salazarysanchez.com/entradas/2018-09-01-Bits-Libres-Feliz-Cumpleanos.html) _Por Chico_
+
+**Agosto 2018** [Migración](http://www.gulag.org.mx/entradas/2018-08-01-Bits-Libres-Migracion.html) _Por Chico_
+
+**Julio 2018** [Vamos ganando, pero...](http://www.gulag.org.mx/entradas/2018-07-01-Bits-Libres-Vamos-ganando-pero.html) _Por Chico_
+
+**Junio 2018** [Interesarnos en la política](http://www.gulag.org.mx/entradas/2018-06-02-Bits-Libres-Interesarnos-en-la-politica.html) _Por Chico_
+
+**Mayo 2018** [Sistemas de votación](http://www.gulag.org.mx/entradas/2018-05-03-Bits-Libres-Sistemas-de-votacion.html) _Por Chico_
+
+**Abril 2018** [Documento libre](http://www.gulag.org.mx/entradas/2018-04-02-Bits-Libres-Documento-libre.html) _Por Chico_
+
+**Marzo 2018** [Datos personales por un peso](http://www.gulag.org.mx/entradas/2018-03-04-Bits-Libres-datos-personales-por-un-peso.html) _Por Chico_
+
+**Febrero 2018** [Mantener la confianza](http://www.gulag.org.mx/entradas/2018-02-03-Bits-Libres-Mantener-la-confianza.html) _Por Chico_
+
+**Enero 2018** [Adaptarse al cambio](http://www.gulag.org.mx/entradas/2018-01-03-Bits-Libres-Adaptarse-al-cambio.html) _Por Chico_
+
+**Diciembre 2017** [Tiempos de compartir](http://www.gulag.org.mx/entradas/2017-12-03-Bits-Libres-Tiempos-de-compartir.html) _Por Chico_
+
+**Noviembre 2017** [Ahora es más fácil](http://www.gulag.org.mx/entradas/2017-11-02-Bits-Libres-Ahora-es-mas-facil.html) _Por Chico_
+
+**Octubre 2017** [Más transparencia, por favor](http://www.gulag.org.mx/entradas/2017-10-01-Bits-Libres-Mas-transparencia-por-favor.html) _Por Chico_
+
+**Septiembre 2017** [Beneficios de compartir](http://www.gulag.org.mx/entradas/2017-09-01-Bits-Libres-Beneficios-de-compartir.html) _Por Chico_
+
+**Agosto 2017** [Sobre la Neutralidad de la Red](http://www.gulag.org.mx/entradas/2017-08-01-Bits-Libres-Sobre-la-Neutralidad-de-la-Red.html) _Por Chico_
+
+**Julio 2017** [Lean los contratos](http://www.gulag.org.mx/entradas/2017-07-08-Bits-Libres-Lean-Los-Contratos.html) _Por Chico_
+
+**Junio 2017** [[Re]Conociendo nuestros derechos: Derecho a cifrar](http://www.gulag.org.mx/entradas/2017-06-11-Bits-Libres-Derecho-A-Cifrar.html) _Por Chico_
+
+**Mayo 2017** [[Re] Conociendo nuestros derechos: Derecho a la privacidad](http://www.gulag.org.mx/entradas/2017-05-03-Bits-Libres-Derecho-A-La-Privacidad.html) _Por Chico_
+
+**Abril 2017** [Software Libre estadístico](http://www.gulag.org.mx/entradas/2017-04-09-Bits-Libres-Software-Libre-Estadistico.html) _Por Chico_
+
+**Marzo 2017** [Impulsar la Innovación (y II): Cambiar el “no” por “¿qué tal si...?”](http://www.gulag.org.mx/entradas/2017-03-08-Bits-Libres-Impulsar-La-Innovacion-Cambiar-No-Por-Si.html) _Por Chico_
+
+**Febrero 2017** [Impulsar la Innovación (I): Ciencia Ficción](http://www.gulag.org.mx/entradas/2017-02-10-Bits-Libres-Impulsar-La-Innovacion-Ciencia-Ficcion.html) _Por Chico_
+
+**Enero 2017** [¿Por qué me gusta Linux?](http://www.gulag.org.mx/entradas/2017-01-21-Bits-Libres-Por-que-me-gusta-linux.html) _Por Chico_
+
+**Diciembre 2016** [Ser nuestros propios Hackers](http://www.gulag.org.mx/entradas/2016-12-10-Bits-Libres-Ser-Nuestro-Propio-Hacker.html) _Por Chico_
+
+**Noviembre 2016** [Va una idea](http://www.gulag.org.mx/entradas/2016-11-09-Bits-Libres-Va-Una-Idea.html) _Por Chico_
+
+**Octubre 2016** [Soberanía Tecnológica](http://www.gulag.org.mx/entradas/2016-10-05-Bits-Libres-Soberania-Tecnologica.html) _Por Chico_
+
+**Septiembre 2016** [Congreso Software Libre](http://www.gulag.org.mx/entradas/2016-09-07-Bits-Libres-Congreso-Software-Libre.html) _Por Chico_
+
+**Agosto 2016** [Tux en el espacio](http://www.gulag.org.mx/entradas/2016-08-10-Bits-Libres-Tux-Espacio.html) _Por Chico_
+
+**Julio 2016** [Ranking de universidades en Software Libre](http://www.gulag.org.mx/entradas/2016-07-05-Bits-Libres-RuSL.html) _Por Chico_
+
+**Junio 2016** [Datos Abiertos](http://www.gulag.org.mx/entradas/2016-06-14-Bits-Libres-Datos-Abiertos.html) _Por Chico_
+
+**Mayo 2016** [Flisol 2016](http://www.gulag.org.mx/entradas/2016-05-10-Bits-Libres-Flisol-2016.html) _Por Chico_
+
+

--- a/content/articles/2017-05-03-Bits-Libres-Derecho-A-La-Privacidad.md
+++ b/content/articles/2017-05-03-Bits-Libres-Derecho-A-La-Privacidad.md
@@ -1,9 +1,8 @@
-Bits Libres - [Re] Conociendo nuestros derechos: Derecho a la privacidad
-==================================
-
-Fecha: 2017-05-03 13:00
-Autor: Chico
-Categorías: Revista
+Title: Bits Libres - [Re] Conociendo nuestros derechos: Derecho a la privacidad
+Date: 2017-05-03 13:00
+Author: Chico
+Category: Revista
+Tags: Bits Libres, Revista, Articulo
 
 _Publicado en la sección [Bits Libres](http://www.gulag.org.mx/revista/2016-05-10-Bits-Libres.html) del periódico [Entretodos](http://periodicoentretodos.com/), en mayo del 2017_
 

--- a/content/articles/2017-05-13-flisol.md
+++ b/content/articles/2017-05-13-flisol.md
@@ -1,12 +1,11 @@
-FLISOL 2017
-===========
-
-Fecha: 2017-05-13 10:00
-Autor: guabyboy
-Categorías: Install Fest, FLISOL
+Title: FLISOL 2017
+Date: 2017-05-13 10:00
+Author: guabyboy
+Category: FLISOL
+Tags: Install Fest, FLISOL
 
 <center>
-<img class="img-responsive" style="width:70%;height:auto;margin-right:12px;" src="2017-05-13-flisol/LogoFLISoL-2017.png" alt="FLISOL 2017" width="325" height="250">
+<img class="img-responsive" style="width:70%;height:auto;margin-right:12px;" src="{attach}2017-05-13-flisol/LogoFLISoL-2017.png" alt="FLISOL 2017" width="325" height="250">
 </center>
 
 <br />
@@ -18,8 +17,8 @@ Con el objetivo de promover y difundir el uso de Software Libre, el próximo **s
 <br />
 
 <center>
-<a href="2017-05-13-flisol/flisol2017.png">
-<img class="img-responsive" style="width:70%;height:auto;margin-right:12px;" src="2017-05-13-flisol/flisol2017.png" alt="Poster FLISOL 2017" width="325" height="250">
+<a href="{attach}2017-05-13-flisol/flisol2017.png">
+<img class="img-responsive" style="width:70%;height:auto;margin-right:12px;" src="{attach}2017-05-13-flisol/flisol2017.png" alt="Poster FLISOL 2017" width="325" height="250">
 </a>
 </center>
 
@@ -46,8 +45,8 @@ El Festival Latinoamericano de Instalación de Software Libre (FLISOL) **es el e
 #### Mapa
 
 <center>
-<a href="http://www.openstreetmap.org/#map=16/25.5893/-103.5047&amp;layers=N">
-<img class="img-responsive" style="width:60%;height:auto;margin-right:12px;" src="2017-05-13-flisol/OSM-UJED-2017.png" alt="CU-UAdeC" width="325" height="250"><br/><small><a href="http://www.openstreetmap.org/#map=16/25.5893/-103.5047">Ver mapa más grande</a></small>
+<a href="{attach}http://www.openstreetmap.org/#map=16/25.5893/-103.5047&amp;layers=N">
+<img class="img-responsive" style="width:60%;height:auto;margin-right:12px;" src="{attach}2017-05-13-flisol/OSM-UJED-2017.png" alt="CU-UAdeC" width="325" height="250"><br/><small><a href="{attach}http://www.openstreetmap.org/#map=16/25.5893/-103.5047">Ver mapa más grande</a></small>
 </a>
 <br/>
 </center>
@@ -55,8 +54,8 @@ El Festival Latinoamericano de Instalación de Software Libre (FLISOL) **es el e
 <br />
 
 <center>
-<a href="2017-05-13-flisol/FICA-flisol2017.png">
-<img class="img-responsive" style="width:70%;height:auto;margin-right:12px;" src="2017-05-13-flisol/FICA-flisol2017.png" alt="Tercer piso del Edificio G" width="325" height="250">
+<a href="{attach}2017-05-13-flisol/FICA-flisol2017.png">
+<img class="img-responsive" style="width:70%;height:auto;margin-right:12px;" src="{attach}2017-05-13-flisol/FICA-flisol2017.png" alt="Tercer piso del Edificio G" width="325" height="250">
 </a>
 </center>
 

--- a/content/articles/2017-05-20-flisol-resumen.md
+++ b/content/articles/2017-05-20-flisol-resumen.md
@@ -1,9 +1,8 @@
-Resumen FLISOL 2017
-===========
-
-Fecha: 2017-05-20 10:00
-Autor: guabyboy
-Categorías: SoftwareLibre, Flisol
+Title: Resumen FLISOL 2017
+Date: 2017-05-20 10:00
+Author: guabyboy
+Category: Flisol
+Tags: FLISOL, SoftwareLibre
 
 El pasado sábado 13 de mayo, se llevó a cabo el Festival Latinoamericano de Instalación de Software Libre (FLISOL) 2017, en las instalaciones de la Facultad de Ingeniería, Ciencias y Arquitetura de la Universidad Juárez del Estado de Durango, UJED; festival que se realizó por primera vez en la ciudad de Gómez Palacio. Con este año, GULAG lo ha realizado ininterrumpidamente desde el año 2007.
 
@@ -14,7 +13,7 @@ Se contó con la participación de alumnos de la carrera de Ingeniería de Siste
 En esta ocasión se impartieron dos charlas previas al festival; la primera a cargo del CP Gabriel Peña, guabyboy, con el tema "Software Libre en tu Empresa", en la que se tocaron temas como el costo de las licencias privativas, los retos y oportunidades futuras por el posible endurecimiento hacia el uso de software privativo con licencias ilegales y las limitantes actuales que el mismo gobierno establece para el uso del Software Libre y en especial, la limitante hacia GNU/Linux.
 
 <center>
-<img class="img-responsive" style="width:60%;height:auto;margin-right:12px;" src="2017-05-20-flisol-resumen/01-flisol.jpg" alt="guabyboy" width="65" height="50">
+<img class="img-responsive" style="width:60%;height:auto;margin-right:12px;" src="{attach}2017-05-20-flisol-resumen/01-flisol.jpg" alt="guabyboy" width="65" height="50">
 </center>
 
 <br />
@@ -24,7 +23,7 @@ La segunda plática impartida muy a su estilo por el LIc. Antonio Gurza, zerialk
 También tocó el tema de WANNACRY, lo que pone de  manifiesto su actualización constante en temas de seguridad informática.
 
 <center>
-<img class="img-responsive" style="width:50%;height:auto;margin-right:12px;" src="2017-05-20-flisol-resumen/03-flisol.jpg" alt="ZK" width="65" height="50">
+<img class="img-responsive" style="width:50%;height:auto;margin-right:12px;" src="{attach}2017-05-20-flisol-resumen/03-flisol.jpg" alt="ZK" width="65" height="50">
 </center>
 
 <br />
@@ -38,7 +37,7 @@ Siempre se aprende algo nuevo, en esta ocasión al instalar un GNU/Linux Lubuntu
 Al final del evento, como es costumbre, se procedió a un pequeño convivio.
 
 <center>
-<img class="img-responsive" style="width:60%;height:auto;margin-right:12px;" src="2017-05-20-flisol-resumen/05-flisol.jpg" alt="Final" width="65" height="50">
+<img class="img-responsive" style="width:60%;height:auto;margin-right:12px;" src="{attach}2017-05-20-flisol-resumen/05-flisol.jpg" alt="Final" width="65" height="50">
 </center> 
 
 


### PR DESCRIPTION
Este issue se abrió para recuperar los archivos que estaban solamente en el blog anterior, y poder incluirlos junto con el resto de los artículos de la página. Esta PR es para copiar los artículos del archivo del blog hacia el archivo de artículos, con su correspondiente migración a pelican.